### PR TITLE
Update LCalendar.js

### DIFF
--- a/src/js/LCalendar.js
+++ b/src/js/LCalendar.js
@@ -98,11 +98,11 @@ window.LCalendar = (function() {
                     mm: date.getMonth(),
                     dd: date.getDate() - 1
                 };
-                if (/^\d{4}-\d{1,2}-\d{1,2}$/.test(_self.trigger.value)) {
+                if (/^\d{4}年\d{1,2}月\d{1,2}日$/.test(_self.trigger.value)) {
                     rs = _self.trigger.value.match(/(^|-)\d{1,4}/g);
                     dateArr.yy = rs[0] - _self.minY;
-                    dateArr.mm = rs[1].replace(/-/g, "") - 1;
-                    dateArr.dd = rs[2].replace(/-/g, "") - 1;
+                    dateArr.mm = rs[1] - 1;
+                    dateArr.dd = rs[2] - 1;
                 } else {
                     dateArr.yy = dateArr.yy - _self.minY;
                 }


### PR DESCRIPTION
日期框第二次弹出的时候，初始化成输入框的内容；
日期显示框中的格式是“2019年04月22日”，但是判断是时候是按照“2019-04-22”判断的；
这块进行了修正；